### PR TITLE
Set JWT auth token "sub" field by basic auth username instead of "acc…

### DIFF
--- a/app/controllers/api/v2/tokens_controller.rb
+++ b/app/controllers/api/v2/tokens_controller.rb
@@ -28,7 +28,7 @@ class Api::V2::TokensController < Api::BaseController
     auth_scopes = []
     auth_scopes = authorize_scopes(registry) unless registry.nil?
 
-    token = Portus::JwtToken.new(params[:account], params[:service], auth_scopes)
+    token = Portus::JwtToken.new(current_user.username, params[:service], auth_scopes)
     logger.tagged("jwt_token", "claim") { logger.debug token.claim }
     render json: token.encoded_hash
   end


### PR DESCRIPTION
…ount" HTTP GET parameter

Signed-off-by: Christoph Honal <christoph.honal@web.de>
